### PR TITLE
Update 02-self-hosted-pixie.md

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -37,7 +37,7 @@ Get Pixie fully managed with [Pixie Community Cloud](/installing-pixie/install-g
 1. Pick a cloud release version from the [tags](https://github.com/pixie-io/pixie/tags) on the repo. The following should pick the latest release for you.
 
     ```bash
-    export LATEST_CLOUD_RELEASE=$(git tag | grep 'release/cloud'  | sort -r | head -n 1 | awk -F/ '{print $NF}')
+    export LATEST_CLOUD_RELEASE=$(git tag | grep 'release/cloud/prod'  | sort -r | head -n 1 | awk -F/ '{print $NF}')
     ```
 
 1. Checkout the release tag.


### PR DESCRIPTION
Add path to /prod, as this can be copy pasted and will not interfere with Line 46. 
The latest in release/cloud could be from dev, which comes first when we sort.