### PR TITLE
docs: cloudAddr requires port

### DIFF
--- a/src/components/cloudLinkProvider.tsx
+++ b/src/components/cloudLinkProvider.tsx
@@ -22,12 +22,12 @@ const availableClouds = [
   {
     name: 'Cosmic Cloud',
     baseUrl: 'https://work.getcosmic.ai',
-    cloudAddr: 'getcosmic.ai',
+    cloudAddr: 'getcosmic.ai:443',
   },
   {
     name: 'New Relic Cloud',
     baseUrl: 'https://work.withpixie.ai',
-    cloudAddr: 'withpixie.ai',
+    cloudAddr: 'withpixie.ai:443',
   },
 ];
 


### PR DESCRIPTION
I bumped into this when trying to speedrun in `kind`.

```bash
time="2025-03-07T03:34:53Z" level=info msg="Creating a new vizier instance"
time="2025-03-07T03:34:53Z" level=error msg="Failed to get latest Vizier version" error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: address getcosmic.ai: missing port in address\""
time="2025-03-07T03:34:53Z" level=info msg="Failed to deploy new Vizier instance" error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: address getcosmic.ai: missing port in address\""
```

[Specifically here](https://github.com/jfreeland/docs.px.dev/blob/main/content/en/02-installing-pixie/04-install-schemes/03-helm.md?plain=1#L60).