### PR TITLE
docs: Add port to cloudAddr in Helm install command

### DIFF
--- a/content/en/02-installing-pixie/04-install-schemes/03-helm.md
+++ b/content/en/02-installing-pixie/04-install-schemes/03-helm.md
@@ -57,13 +57,13 @@ helm repo add pixie-operator https://artifacts.px.dev/helm_charts/operator \n
 # Get latest information about Pixie chart.
 helm repo update \n
 # Install the Pixie chart (No OLM present on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace \n
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@:443 --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace \n
 # Install the Pixie chart (OLM already exists on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false \n
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@:443 --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false \n
 # Install the Pixie chart (Self-hosting Pixie Cloud)
 helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set devCloudNamespace=plc \n
 # Install Pixie with a memory limit for the PEM pods (per node). 2Gi is the default, 1Gi is the minimum recommended.
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@:443 --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
   `}
 />
 


### PR DESCRIPTION
Fixes: #297


This PR addresses an issue where the official Helm installation guide for the Pixie Operator provides a cloudAddr value without a port. This misconfiguration leads to gRPC connection failures in the vizier-operator, with errors such as
```
transport: Error while dialing dial tcp: address getcosmic.ai: missing port in address.
```
Consequently, the Pixie Edge Module (PEM) and Agent fail to deploy correctly.
To resolve this, the example Helm commands in the documentation have been updated to include the standard :443 port with the cloudAddr value. This ensures that users can follow the guide without encountering connection errors during installation.